### PR TITLE
Password validation in user registration

### DIFF
--- a/lib/modules/auth/signup/components/form_field.dart
+++ b/lib/modules/auth/signup/components/form_field.dart
@@ -7,6 +7,7 @@ class CustomFormField extends StatelessWidget {
   final TextInputType? inputType;
   final bool isPassword;
   final TextEditingController? controller;
+  final String? errorText;
 
   const CustomFormField({
     super.key,
@@ -16,6 +17,7 @@ class CustomFormField extends StatelessWidget {
     this.inputType,
     this.isPassword = false,
     this.controller,
+    this.errorText,
   });
 
   @override
@@ -34,6 +36,7 @@ class CustomFormField extends StatelessWidget {
           focusedBorder: OutlineInputBorder(
             borderSide: BorderSide(color: Colors.orange),
           ),
+          errorText: errorText,
         ),
       ),
     );

--- a/lib/modules/auth/signup/screen/registration_screen.dart
+++ b/lib/modules/auth/signup/screen/registration_screen.dart
@@ -21,6 +21,7 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
 
   bool _termsAccepted = false;
   bool _isFormValid = false;
+  String? _passwordError;
 
   @override
   void initState() {
@@ -51,7 +52,14 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
 
   void _validateForm() {
     setState(() {
-      // Validar que todos los campos estén llenos
+      // Verificar si las contraseñas coinciden
+      if (_passwordController.text != _confirmPasswordController.text) {
+        _passwordError = 'Las contraseñas no coinciden';
+      } else {
+        _passwordError = null;
+      }
+
+      // Validar que todos los campos estén completos y las contraseñas coincidan
       _isFormValid = _usernameController.text.isNotEmpty &&
           _birthdateController.text.isNotEmpty &&
           _countryController.text.isNotEmpty &&
@@ -59,7 +67,8 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
           _emailController.text.isNotEmpty &&
           _passwordController.text.isNotEmpty &&
           _confirmPasswordController.text.isNotEmpty &&
-          _termsAccepted;
+          _termsAccepted &&
+          _passwordError == null;
     });
   }
 
@@ -172,6 +181,7 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
               hintText: "Repite tu contraseña",
               prefixIcon: Icons.lock,
               isPassword: true,
+              errorText: _passwordError,
             ),
 
             const SizedBox(height: 20),

--- a/lib/modules/auth/signup/screen/registration_screen.dart
+++ b/lib/modules/auth/signup/screen/registration_screen.dart
@@ -177,8 +177,8 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
 
             CustomFormField(
               controller: _confirmPasswordController,
-              label: "Repetir contraseña",
-              hintText: "Repite tu contraseña",
+              label: "Confirmar contraseña",
+              hintText: "Confirma tu contraseña",
               prefixIcon: Icons.lock,
               isPassword: true,
               errorText: _passwordError,


### PR DESCRIPTION
- [ ✅ ] Se implementó la validación de las contraseñas en el formulario de registro.
- [ ✅  ] Si las contraseñas no coinciden, se muestra un mensaje de error debajo del campo "Repetir contraseña".

Cambios importantes:

- [ ✅ ] Se modificó la función _validateForm para incluir la validación de las contraseñas.
- [ ✅ ] Se pasó un parámetro errorText a CustomFormField para mostrar el mensaje de error en el campo "Repetir contraseña".

Imagen de Referencia:
![image](https://github.com/user-attachments/assets/aa9d3fc1-704e-4582-856b-8ecba3ed24d8)
